### PR TITLE
feat: workaround for physical esim adapter

### DIFF
--- a/app/src/main/java/io/github/soclear/oneuix/data/Preference.kt
+++ b/app/src/main/java/io/github/soclear/oneuix/data/Preference.kt
@@ -45,6 +45,8 @@ data class Preference(
             val statusBarClockFormat: String = "HH:mm",
             val updateStatusBarClockEverySecond: Boolean = false,
             val hideSecureFolderStatusBarIcon: Boolean = false,
+            val physicalEsimAdapterWorkaround: Boolean = false,
+            val physicalEsimAdapterSimSlot: Int = 1,
             val doubleTapStatusBarToSleep: Boolean = false,
             val modifyStatusBarMaxNotificationIcons: Boolean = false,
             val statusBarMaxNotificationIcons: Int = 4,

--- a/app/src/main/java/io/github/soclear/oneuix/hook/Main.kt
+++ b/app/src/main/java/io/github/soclear/oneuix/hook/Main.kt
@@ -238,6 +238,13 @@ class Main : IXposedHookLoadPackage, IXposedHookInitPackageResources {
                     SystemUI.hideSecureFolderStatusBarIcon(lpparam)
                 }
 
+                if (preference.systemUI.statusBar.physicalEsimAdapterWorkaround) {
+                    SystemUI.workaroundPhysicalEsimAdapter(
+                        lpparam,
+                        preference.systemUI.statusBar.physicalEsimAdapterSimSlot
+                    )
+                }
+
                 if (preference.systemUI.statusBar.doubleTapStatusBarToSleep) {
                     SystemUI.doubleTapStatusBarToSleep(lpparam)
                 }

--- a/app/src/main/java/io/github/soclear/oneuix/hook/SystemUI.kt
+++ b/app/src/main/java/io/github/soclear/oneuix/hook/SystemUI.kt
@@ -8,7 +8,9 @@ import android.os.Handler
 import android.os.Looper
 import android.os.PowerManager
 import android.os.SystemClock
+import android.telephony.ServiceState
 import android.telephony.SubscriptionManager
+import android.telephony.TelephonyManager
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.Gravity
@@ -42,7 +44,6 @@ import java.lang.reflect.Field
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Collections
-import java.util.Locale
 import java.util.WeakHashMap
 import kotlin.math.roundToInt
 
@@ -56,8 +57,11 @@ object SystemUI {
     private val hiddenMobileViews: MutableSet<View> =
         Collections.synchronizedSet(Collections.newSetFromMap(WeakHashMap()))
     private val unavailableCarrierSlots = mutableSetOf<Int>()
+    private val telephonyManagersBySubId = mutableMapOf<Int, TelephonyManager>()
     private val unavailableCarrierTexts: MutableSet<String> =
         Collections.synchronizedSet(mutableSetOf())
+    private var physicalEsimAdapterContext: Context? = null
+    private var unavailableCarrierTextsLoaded = false
 
     private val unavailableCarrierTextResourceNames = listOf(
         "emergency_calls_only",
@@ -658,7 +662,9 @@ object SystemUI {
                 "com.android.systemui.statusbar.policy.ConfigurationController",
                 object : XC_MethodHook() {
                     override fun afterHookedMethod(param: MethodHookParam) {
-                        updateUnavailableCarrierTexts(param.args[0] as? Context)
+                        val context = param.args[0] as? Context
+                        updatePhysicalEsimAdapterContext(context)
+                        updateUnavailableCarrierTexts(context)
                         val viewModel = param.args[3] ?: return
                         val slot = getMobileViewModelSlot(viewModel) ?: return
                         if (slot in selectedSlots) {
@@ -726,8 +732,13 @@ object SystemUI {
                         val state = param.args[0] ?: return
                         val slot = SubscriptionManager.getSlotIndex(getIntField(state, "subId"))
                         if (slot in selectedSlots) {
-                            updateCarrierSlotAvailabilityFromMobileState(state, slot)
-                            trackMobileView(param.thisObject as? View, slot, selectedSlots)
+                            val view = param.thisObject as? View
+                            updateCarrierSlotAvailabilityFromMobileState(
+                                state = state,
+                                slot = slot,
+                                context = view?.context
+                            )
+                            trackMobileView(view, slot, selectedSlots)
                         }
                     }
                 }
@@ -747,7 +758,10 @@ object SystemUI {
                         param.args
                             .filterIsInstance<Context>()
                             .firstOrNull()
-                            ?.let(::updateUnavailableCarrierTexts)
+                            ?.let { context ->
+                                updatePhysicalEsimAdapterContext(context)
+                                updateUnavailableCarrierTexts(context)
+                            }
                     }
                 }
             )
@@ -760,7 +774,11 @@ object SystemUI {
                 "com.android.keyguard.CarrierTextManager", loadPackageParam.classLoader, "postToCallback",
                 $$"com.android.keyguard.CarrierTextManager$CarrierTextCallbackInfo", object : XC_MethodHook() {
                     override fun beforeHookedMethod(param: MethodHookParam) {
-                        sanitizeCarrierTextCallbackInfo(param.args[0] ?: return, selectedSlots)
+                        sanitizeCarrierTextCallbackInfo(
+                            info = param.args[0] ?: return,
+                            selectedSlots = selectedSlots,
+                            context = physicalEsimAdapterContext
+                        )
                         refreshTrackedMobileViews(selectedSlots)
                     }
                 }
@@ -820,7 +838,43 @@ object SystemUI {
     private fun isUnavailableCarrierSlot(slot: Int): Boolean =
         synchronized(unavailableCarrierSlots) { slot in unavailableCarrierSlots }
 
-    private fun updateCarrierSlotAvailabilityFromMobileState(state: Any, slot: Int) {
+    private fun updateCarrierSlotAvailabilityFromMobileState(state: Any, slot: Int, context: Context?) {
+        val unavailable = getUnavailableServiceState(context, getIntField(state, "subId"))
+            ?: isUnavailableMobileStateText(state)
+
+        synchronized(unavailableCarrierSlots) {
+            if (unavailable) {
+                unavailableCarrierSlots.add(slot)
+            } else {
+                unavailableCarrierSlots.remove(slot)
+            }
+        }
+    }
+
+    private fun getUnavailableServiceState(context: Context?, subId: Int): Boolean? {
+        val telephonyManager = getTelephonyManager(context, subId) ?: return null
+        return runCatching {
+            when (telephonyManager.serviceState?.state) {
+                ServiceState.STATE_OUT_OF_SERVICE,
+                ServiceState.STATE_EMERGENCY_ONLY -> true
+                null -> null
+                else -> false
+            }
+        }.getOrNull()
+    }
+
+    private fun getTelephonyManager(context: Context?, subId: Int): TelephonyManager? {
+        if (context == null || !SubscriptionManager.isValidSubscriptionId(subId)) return null
+        synchronized(telephonyManagersBySubId) {
+            telephonyManagersBySubId[subId]?.let { return it }
+            return context
+                .getSystemService(TelephonyManager::class.java)
+                ?.createForSubscriptionId(subId)
+                ?.also { telephonyManagersBySubId[subId] = it }
+        }
+    }
+
+    private fun isUnavailableMobileStateText(state: Any): Boolean {
         val stateText = readFieldValue(
             state,
             listOf(
@@ -831,21 +885,13 @@ object SystemUI {
             )
         )?.toString().orEmpty()
 
-        if (stateText.isEmpty()) return
-
-        synchronized(unavailableCarrierSlots) {
-            if (isUnavailableCarrierText(stateText)) {
-                unavailableCarrierSlots.add(slot)
-            } else {
-                unavailableCarrierSlots.remove(slot)
-            }
-        }
+        return stateText.isNotEmpty() && isUnavailableCarrierText(stateText)
     }
 
-    private fun sanitizeCarrierTextCallbackInfo(info: Any, selectedSlots: Set<Int>) {
+    private fun sanitizeCarrierTextCallbackInfo(info: Any, selectedSlots: Set<Int>, context: Context?) {
         val carrierList = readCarrierListField(info)
         if (carrierList != null) {
-            sanitizeCarrierList(info, carrierList, selectedSlots)
+            sanitizeCarrierList(info, carrierList, selectedSlots, context)
             return
         }
 
@@ -854,13 +900,29 @@ object SystemUI {
             .orEmpty()
         if (carrierText.isEmpty()) return
 
+        val unavailableSlots = mutableSetOf<Int>()
+        val availableSlots = mutableSetOf<Int>()
+        readIntArrayField(info, listOf("subscriptionIds", "subs", "subIds"))
+            ?.forEach { subId ->
+                val slot = SubscriptionManager.getSlotIndex(subId)
+                if (slot !in selectedSlots) return@forEach
+                when (getUnavailableServiceState(context, subId)) {
+                    true -> unavailableSlots.add(slot)
+                    false -> availableSlots.add(slot)
+                    null -> Unit
+                }
+            }
+
         synchronized(unavailableCarrierSlots) {
-            if (isUnavailableCarrierText(carrierText)) {
+            unavailableCarrierSlots.removeAll(availableSlots)
+            if (unavailableSlots.isNotEmpty()) {
+                unavailableCarrierSlots.addAll(unavailableSlots)
+                setFieldValue(info, "carrierText", "")
+                setFieldValue(info, "carrierTextShort", "")
+            } else if (availableSlots.isEmpty() && isUnavailableCarrierText(carrierText)) {
                 unavailableCarrierSlots.addAll(selectedSlots)
                 setFieldValue(info, "carrierText", "")
                 setFieldValue(info, "carrierTextShort", "")
-            } else {
-                unavailableCarrierSlots.removeAll(selectedSlots)
             }
         }
     }
@@ -868,34 +930,43 @@ object SystemUI {
     private fun sanitizeCarrierList(
         info: Any,
         carrierList: CarrierListField,
-        selectedSlots: Set<Int>
+        selectedSlots: Set<Int>,
+        context: Context?
     ) {
         val subscriptionIds = readIntArrayField(info, listOf("subscriptionIds", "subs", "subIds"))
         val originalCarriers = carrierList.values
         val sanitizedCarriers = originalCarriers.toMutableList()
-        val observedSelectedSlots = mutableSetOf<Int>()
         val unavailableSelectedSlots = mutableSetOf<Int>()
+        val availableSelectedSlots = mutableSetOf<Int>()
 
         originalCarriers.forEachIndexed { index, carrier ->
             val slot = getCarrierSlot(index, subscriptionIds) ?: return@forEachIndexed
             if (slot !in selectedSlots) return@forEachIndexed
 
-            observedSelectedSlots.add(slot)
+            val serviceUnavailable = subscriptionIds
+                ?.getOrNull(index)
+                ?.let { getUnavailableServiceState(context, it) }
             val carrierText = carrier?.toString().orEmpty()
-            if (isUnavailableCarrierText(carrierText)) {
-                unavailableSelectedSlots.add(slot)
-                sanitizedCarriers[index] = ""
+            when {
+                serviceUnavailable == true -> {
+                    unavailableSelectedSlots.add(slot)
+                    sanitizedCarriers[index] = ""
+                }
+
+                serviceUnavailable == false -> {
+                    availableSelectedSlots.add(slot)
+                }
+
+                isUnavailableCarrierText(carrierText) -> {
+                    unavailableSelectedSlots.add(slot)
+                    sanitizedCarriers[index] = ""
+                }
             }
         }
 
         synchronized(unavailableCarrierSlots) {
-            observedSelectedSlots.forEach { slot ->
-                if (slot in unavailableSelectedSlots) {
-                    unavailableCarrierSlots.add(slot)
-                } else {
-                    unavailableCarrierSlots.remove(slot)
-                }
-            }
+            unavailableCarrierSlots.removeAll(availableSelectedSlots)
+            unavailableCarrierSlots.addAll(unavailableSelectedSlots)
         }
 
         if (unavailableSelectedSlots.isEmpty()) return
@@ -916,6 +987,7 @@ object SystemUI {
     }
 
     private fun updateUnavailableCarrierTexts(context: Context?) {
+        if (unavailableCarrierTextsLoaded) return
         context ?: return
         val packages = listOf(context.packageName, "android")
         val labels = unavailableCarrierTextResourceNames.flatMap { name ->
@@ -927,29 +999,57 @@ object SystemUI {
 
         if (labels.isEmpty()) return
 
-        unavailableCarrierTexts.addAll(labels.map(::normalizeCarrierText).filter(String::isNotBlank))
+        synchronized(unavailableCarrierTexts) {
+            unavailableCarrierTexts.addAll(labels.map(::normalizeCarrierText).filter(String::isNotBlank))
+            unavailableCarrierTextsLoaded = true
+        }
     }
 
     private fun isUnavailableCarrierText(text: String): Boolean {
         val normalized = normalizeCarrierText(text)
         if (normalized.isBlank()) return false
 
-        val resourceLabels = synchronized(unavailableCarrierTexts) {
-            unavailableCarrierTexts.toSet()
-        }
-        val unavailableLabels = resourceLabels.ifEmpty { unavailableCarrierTextFallbacks }
-
-        return unavailableLabels.any { label ->
-            label.isNotBlank() && (normalized == label || normalized.contains(label))
+        return synchronized(unavailableCarrierTexts) {
+            val unavailableLabels = unavailableCarrierTexts.ifEmpty { unavailableCarrierTextFallbacks }
+            unavailableLabels.any { label ->
+                label.isNotBlank() && (normalized == label || normalized.contains(label))
+            }
         }
     }
 
-    private fun normalizeCarrierText(text: String): String =
-        text
-            .replace(Regex("[\\u200e\\u200f\\u202a-\\u202e\\u2066-\\u2069]"), "")
-            .replace(Regex("\\s+"), " ")
-            .trim()
-            .lowercase(Locale.ROOT)
+    private fun normalizeCarrierText(text: String): String {
+        val normalized = StringBuilder(text.length)
+        var pendingSpace = false
+        text.forEach { char ->
+            when {
+                isCarrierTextControlChar(char) -> Unit
+                char.isWhitespace() -> {
+                    if (normalized.isNotEmpty()) pendingSpace = true
+                }
+                else -> {
+                    if (pendingSpace) {
+                        normalized.append(' ')
+                        pendingSpace = false
+                    }
+                    normalized.append(char.lowercaseChar())
+                }
+            }
+        }
+        return normalized.toString()
+    }
+
+    private fun isCarrierTextControlChar(char: Char): Boolean =
+        when (char.code) {
+            0x200e, 0x200f -> true
+            in 0x202a..0x202e -> true
+            in 0x2066..0x2069 -> true
+            else -> false
+        }
+
+    private fun updatePhysicalEsimAdapterContext(context: Context?) {
+        context ?: return
+        physicalEsimAdapterContext = context.applicationContext ?: context
+    }
 
     private fun buildCarrierText(
         originalCarriers: List<CharSequence?>,

--- a/app/src/main/java/io/github/soclear/oneuix/hook/SystemUI.kt
+++ b/app/src/main/java/io/github/soclear/oneuix/hook/SystemUI.kt
@@ -58,9 +58,12 @@ object SystemUI {
         Collections.synchronizedSet(Collections.newSetFromMap(WeakHashMap()))
     private val unavailableCarrierSlots = mutableSetOf<Int>()
     private val telephonyManagersBySubId = mutableMapOf<Int, TelephonyManager>()
+    private val fieldCache: MutableMap<FieldCacheKey, Field?> =
+        Collections.synchronizedMap(mutableMapOf())
     private val unavailableCarrierTexts: MutableSet<String> =
         Collections.synchronizedSet(mutableSetOf())
     private var physicalEsimAdapterContext: Context? = null
+    @Volatile
     private var unavailableCarrierTextsLoaded = false
 
     private val unavailableCarrierTextResourceNames = listOf(
@@ -772,7 +775,7 @@ object SystemUI {
         try {
             findAndHookMethod(
                 "com.android.keyguard.CarrierTextManager", loadPackageParam.classLoader, "postToCallback",
-                $$"com.android.keyguard.CarrierTextManager$CarrierTextCallbackInfo", object : XC_MethodHook() {
+                "com.android.keyguard.CarrierTextManager\$CarrierTextCallbackInfo", object : XC_MethodHook() {
                     override fun beforeHookedMethod(param: MethodHookParam) {
                         sanitizeCarrierTextCallbackInfo(
                             info = param.args[0] ?: return,
@@ -821,6 +824,11 @@ object SystemUI {
     }
 
     private fun applyMobileViewVisibility(view: View, slot: Int, selectedSlots: Set<Int>) {
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            view.post { applyMobileViewVisibility(view, slot, selectedSlots) }
+            return
+        }
+
         if (slot in selectedSlots && isUnavailableCarrierSlot(slot)) {
             hiddenMobileViews.add(view)
             view.visibility = View.GONE
@@ -1093,6 +1101,11 @@ object SystemUI {
         val values: List<CharSequence?>
     )
 
+    private data class FieldCacheKey(
+        val clazz: Class<*>,
+        val name: String
+    )
+
     private fun readCarrierListField(info: Any): CarrierListField? {
         val field = findField(
             info,
@@ -1149,15 +1162,26 @@ object SystemUI {
         var clazz: Class<*>? = instance.javaClass
         while (clazz != null) {
             names.forEach { name ->
-                runCatching {
-                    val field = clazz.getDeclaredField(name)
-                    field.isAccessible = true
-                    return field
-                }
+                findDeclaredField(clazz, name)?.let { return it }
             }
             clazz = clazz.superclass
         }
         return null
+    }
+
+    private fun findDeclaredField(clazz: Class<*>, name: String): Field? {
+        val cacheKey = FieldCacheKey(clazz, name)
+        synchronized(fieldCache) {
+            if (fieldCache.containsKey(cacheKey)) return fieldCache[cacheKey]
+        }
+
+        val field = runCatching {
+            clazz.getDeclaredField(name).apply { isAccessible = true }
+        }.getOrNull()
+        synchronized(fieldCache) {
+            fieldCache[cacheKey] = field
+        }
+        return field
     }
 
     fun setStatusBarMaxNotificationIcons(loadPackageParam: LoadPackageParam, max: Int) {

--- a/app/src/main/java/io/github/soclear/oneuix/hook/SystemUI.kt
+++ b/app/src/main/java/io/github/soclear/oneuix/hook/SystemUI.kt
@@ -8,6 +8,7 @@ import android.os.Handler
 import android.os.Looper
 import android.os.PowerManager
 import android.os.SystemClock
+import android.telephony.SubscriptionManager
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.Gravity
@@ -23,6 +24,7 @@ import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.XC_MethodReplacement
 import de.robv.android.xposed.XC_MethodReplacement.returnConstant
 import de.robv.android.xposed.XposedBridge
+import de.robv.android.xposed.XposedBridge.hookAllConstructors
 import de.robv.android.xposed.XposedBridge.hookAllMethods
 import de.robv.android.xposed.XposedHelpers.callMethod
 import de.robv.android.xposed.XposedHelpers.findAndHookConstructor
@@ -36,12 +38,44 @@ import de.robv.android.xposed.callbacks.XC_InitPackageResources.InitPackageResou
 import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam
 import io.github.soclear.oneuix.data.Package
 import io.github.soclear.oneuix.hook.util.TraditionalChineseCalendar
+import java.lang.reflect.Field
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.util.Collections
+import java.util.Locale
+import java.util.WeakHashMap
 import kotlin.math.roundToInt
 
 
 object SystemUI {
+    private const val PHYSICAL_ESIM_ADAPTER_SIM_1 = 0
+    private const val PHYSICAL_ESIM_ADAPTER_SIM_2 = 1
+    private const val PHYSICAL_ESIM_ADAPTER_BOTH = 2
+    private val trackedMobileViewSlots: MutableMap<View, Int> =
+        Collections.synchronizedMap(WeakHashMap())
+    private val hiddenMobileViews: MutableSet<View> =
+        Collections.synchronizedSet(Collections.newSetFromMap(WeakHashMap()))
+    private val unavailableCarrierSlots = mutableSetOf<Int>()
+    private val unavailableCarrierTexts: MutableSet<String> =
+        Collections.synchronizedSet(mutableSetOf())
+
+    private val unavailableCarrierTextResourceNames = listOf(
+        "emergency_calls_only",
+        "lockscreen_carrier_default",
+        "kg_emergency_calls_only",
+        "keyguard_emergency_calls_only",
+        "keyguard_carrier_default",
+        "status_bar_no_service",
+        "status_bar_network_name_no_service",
+        "mobile_network_no_service",
+        "no_service"
+    )
+
+    private val unavailableCarrierTextFallbacks = setOf(
+        "emergency calls only",
+        "no service"
+    )
+
     enum class QsBar {
         MediaPlayer,
         NearbyDevicesAndDeviceControl,
@@ -116,6 +150,7 @@ object SystemUI {
             XposedBridge.log(t)
         }
     }
+
 
     fun hideBatteryPercentageSign(resparam: InitPackageResourcesParam) {
         if (resparam.packageName != Package.SYSTEMUI ||
@@ -605,6 +640,424 @@ object SystemUI {
         } catch (t: Throwable) {
             XposedBridge.log(t)
         }
+    }
+
+    fun workaroundPhysicalEsimAdapter(loadPackageParam: LoadPackageParam, simSlotMode: Int) {
+        if (loadPackageParam.packageName != Package.SYSTEMUI) return
+        val selectedSlots = selectedPhysicalEsimAdapterSlots(simSlotMode)
+
+        try {
+            findAndHookMethod(
+                "com.android.systemui.statusbar.pipeline.mobile.ui.view.ModernStatusBarMobileView",
+                loadPackageParam.classLoader,
+                "constructAndBind",
+                Context::class.java,
+                "com.android.systemui.statusbar.pipeline.mobile.ui.MobileViewLogger",
+                String::class.java,
+                "com.android.systemui.statusbar.pipeline.mobile.ui.viewmodel.LocationBasedMobileViewModel",
+                "com.android.systemui.statusbar.policy.ConfigurationController",
+                object : XC_MethodHook() {
+                    override fun afterHookedMethod(param: MethodHookParam) {
+                        updateUnavailableCarrierTexts(param.args[0] as? Context)
+                        val viewModel = param.args[3] ?: return
+                        val slot = getMobileViewModelSlot(viewModel) ?: return
+                        if (slot in selectedSlots) {
+                            trackMobileView(param.result as? View, slot, selectedSlots)
+                        }
+                    }
+                }
+            )
+        } catch (t: Throwable) {
+            XposedBridge.log(t)
+        }
+
+        try {
+            findAndHookMethod(
+                "com.android.systemui.statusbar.pipeline.shared.ui.view.ModernStatusBarView",
+                loadPackageParam.classLoader,
+                "setVisibleState",
+                Int::class.javaPrimitiveType,
+                Boolean::class.javaPrimitiveType,
+                object : XC_MethodHook() {
+                    override fun beforeHookedMethod(param: MethodHookParam) {
+                        val slot = trackedMobileViewSlots[param.thisObject as? View] ?: return
+                        if (slot in selectedSlots && isUnavailableCarrierSlot(slot)) {
+                            param.args[0] = 2
+                        }
+                    }
+
+                    override fun afterHookedMethod(param: MethodHookParam) {
+                        val view = param.thisObject as? View ?: return
+                        val slot = trackedMobileViewSlots[view] ?: return
+                        applyMobileViewVisibility(view, slot, selectedSlots)
+                    }
+                }
+            )
+        } catch (t: Throwable) {
+            XposedBridge.log(t)
+        }
+
+        try {
+            findAndHookMethod(
+                "com.android.systemui.statusbar.pipeline.shared.ui.view.ModernStatusBarView",
+                loadPackageParam.classLoader,
+                "isIconVisible",
+                object : XC_MethodHook() {
+                    override fun beforeHookedMethod(param: MethodHookParam) {
+                        val slot = trackedMobileViewSlots[param.thisObject as? View] ?: return
+                        if (slot in selectedSlots && isUnavailableCarrierSlot(slot)) {
+                            param.result = false
+                        }
+                    }
+                }
+            )
+        } catch (t: Throwable) {
+            XposedBridge.log(t)
+        }
+
+        try {
+            findAndHookMethod(
+                "com.android.systemui.statusbar.StatusBarMobileView",
+                loadPackageParam.classLoader,
+                "applyMobileState",
+                "com.android.systemui.statusbar.phone.StatusBarSignalPolicy\$MobileIconState",
+                object : XC_MethodHook() {
+                    override fun afterHookedMethod(param: MethodHookParam) {
+                        val state = param.args[0] ?: return
+                        val slot = SubscriptionManager.getSlotIndex(getIntField(state, "subId"))
+                        if (slot in selectedSlots) {
+                            updateCarrierSlotAvailabilityFromMobileState(state, slot)
+                            trackMobileView(param.thisObject as? View, slot, selectedSlots)
+                        }
+                    }
+                }
+            )
+        } catch (t: Throwable) {
+            XposedBridge.log(t)
+        }
+
+        try {
+            hookAllConstructors(
+                findClass(
+                    "com.android.keyguard.CarrierTextManager",
+                    loadPackageParam.classLoader
+                ),
+                object : XC_MethodHook() {
+                    override fun afterHookedMethod(param: MethodHookParam) {
+                        param.args
+                            .filterIsInstance<Context>()
+                            .firstOrNull()
+                            ?.let(::updateUnavailableCarrierTexts)
+                    }
+                }
+            )
+        } catch (t: Throwable) {
+            XposedBridge.log(t)
+        }
+
+        try {
+            findAndHookMethod(
+                "com.android.keyguard.CarrierTextManager", loadPackageParam.classLoader, "postToCallback",
+                $$"com.android.keyguard.CarrierTextManager$CarrierTextCallbackInfo", object : XC_MethodHook() {
+                    override fun beforeHookedMethod(param: MethodHookParam) {
+                        sanitizeCarrierTextCallbackInfo(param.args[0] ?: return, selectedSlots)
+                        refreshTrackedMobileViews(selectedSlots)
+                    }
+                }
+            )
+        } catch (t: Throwable) {
+            XposedBridge.log(t)
+        }
+    }
+
+    private fun getMobileViewModelSlot(viewModel: Any): Int? {
+        runCatching {
+            val commonImpl = getObjectField(viewModel, "commonImpl")
+            val slot = getIntField(commonImpl, "slotId")
+            if (slot >= 0) return slot
+        }
+
+        runCatching {
+            val subId = callMethod(viewModel, "getSubscriptionId") as Int
+            val slot = SubscriptionManager.getSlotIndex(subId)
+            if (slot >= 0) return slot
+        }
+
+        return null
+    }
+
+    private fun selectedPhysicalEsimAdapterSlots(simSlotMode: Int): Set<Int> =
+        when (simSlotMode) {
+            PHYSICAL_ESIM_ADAPTER_SIM_1 -> setOf(PHYSICAL_ESIM_ADAPTER_SIM_1)
+            PHYSICAL_ESIM_ADAPTER_BOTH -> setOf(
+                PHYSICAL_ESIM_ADAPTER_SIM_1,
+                PHYSICAL_ESIM_ADAPTER_SIM_2
+            )
+            else -> setOf(PHYSICAL_ESIM_ADAPTER_SIM_2)
+        }
+
+    private fun trackMobileView(view: View?, slot: Int, selectedSlots: Set<Int>) {
+        view ?: return
+        trackedMobileViewSlots[view] = slot
+        applyMobileViewVisibility(view, slot, selectedSlots)
+    }
+
+    private fun applyMobileViewVisibility(view: View, slot: Int, selectedSlots: Set<Int>) {
+        if (slot in selectedSlots && isUnavailableCarrierSlot(slot)) {
+            hiddenMobileViews.add(view)
+            view.visibility = View.GONE
+        } else if (slot in selectedSlots && hiddenMobileViews.remove(view)) {
+            view.visibility = View.VISIBLE
+        }
+    }
+
+    private fun refreshTrackedMobileViews(selectedSlots: Set<Int>) {
+        trackedMobileViewSlots.entries.toList().forEach { (view, slot) ->
+            applyMobileViewVisibility(view, slot, selectedSlots)
+        }
+    }
+
+    private fun isUnavailableCarrierSlot(slot: Int): Boolean =
+        synchronized(unavailableCarrierSlots) { slot in unavailableCarrierSlots }
+
+    private fun updateCarrierSlotAvailabilityFromMobileState(state: Any, slot: Int) {
+        val stateText = readFieldValue(
+            state,
+            listOf(
+                "contentDescription",
+                "typeContentDescription",
+                "networkName",
+                "carrierName"
+            )
+        )?.toString().orEmpty()
+
+        if (stateText.isEmpty()) return
+
+        synchronized(unavailableCarrierSlots) {
+            if (isUnavailableCarrierText(stateText)) {
+                unavailableCarrierSlots.add(slot)
+            } else {
+                unavailableCarrierSlots.remove(slot)
+            }
+        }
+    }
+
+    private fun sanitizeCarrierTextCallbackInfo(info: Any, selectedSlots: Set<Int>) {
+        val carrierList = readCarrierListField(info)
+        if (carrierList != null) {
+            sanitizeCarrierList(info, carrierList, selectedSlots)
+            return
+        }
+
+        val carrierText = readFieldValue(info, listOf("carrierText", "carrierTextShort"))
+            ?.toString()
+            .orEmpty()
+        if (carrierText.isEmpty()) return
+
+        synchronized(unavailableCarrierSlots) {
+            if (isUnavailableCarrierText(carrierText)) {
+                unavailableCarrierSlots.addAll(selectedSlots)
+                setFieldValue(info, "carrierText", "")
+                setFieldValue(info, "carrierTextShort", "")
+            } else {
+                unavailableCarrierSlots.removeAll(selectedSlots)
+            }
+        }
+    }
+
+    private fun sanitizeCarrierList(
+        info: Any,
+        carrierList: CarrierListField,
+        selectedSlots: Set<Int>
+    ) {
+        val subscriptionIds = readIntArrayField(info, listOf("subscriptionIds", "subs", "subIds"))
+        val originalCarriers = carrierList.values
+        val sanitizedCarriers = originalCarriers.toMutableList()
+        val observedSelectedSlots = mutableSetOf<Int>()
+        val unavailableSelectedSlots = mutableSetOf<Int>()
+
+        originalCarriers.forEachIndexed { index, carrier ->
+            val slot = getCarrierSlot(index, subscriptionIds) ?: return@forEachIndexed
+            if (slot !in selectedSlots) return@forEachIndexed
+
+            observedSelectedSlots.add(slot)
+            val carrierText = carrier?.toString().orEmpty()
+            if (isUnavailableCarrierText(carrierText)) {
+                unavailableSelectedSlots.add(slot)
+                sanitizedCarriers[index] = ""
+            }
+        }
+
+        synchronized(unavailableCarrierSlots) {
+            observedSelectedSlots.forEach { slot ->
+                if (slot in unavailableSelectedSlots) {
+                    unavailableCarrierSlots.add(slot)
+                } else {
+                    unavailableCarrierSlots.remove(slot)
+                }
+            }
+        }
+
+        if (unavailableSelectedSlots.isEmpty()) return
+
+        writeCarrierListField(carrierList, sanitizedCarriers)
+        val carrierText = buildCarrierText(originalCarriers, sanitizedCarriers)
+        setFieldValue(info, "carrierText", carrierText)
+        setFieldValue(info, "carrierTextShort", carrierText)
+    }
+
+    private fun getCarrierSlot(index: Int, subscriptionIds: IntArray?): Int? {
+        val subId = subscriptionIds?.getOrNull(index)
+        if (subId != null) {
+            val slot = SubscriptionManager.getSlotIndex(subId)
+            if (slot >= 0) return slot
+        }
+        return index.takeIf { it == PHYSICAL_ESIM_ADAPTER_SIM_1 || it == PHYSICAL_ESIM_ADAPTER_SIM_2 }
+    }
+
+    private fun updateUnavailableCarrierTexts(context: Context?) {
+        context ?: return
+        val packages = listOf(context.packageName, "android")
+        val labels = unavailableCarrierTextResourceNames.flatMap { name ->
+            packages.mapNotNull { packageName ->
+                val id = context.resources.getIdentifier(name, "string", packageName)
+                if (id == 0) null else runCatching { context.getString(id) }.getOrNull()
+            }
+        }
+
+        if (labels.isEmpty()) return
+
+        unavailableCarrierTexts.addAll(labels.map(::normalizeCarrierText).filter(String::isNotBlank))
+    }
+
+    private fun isUnavailableCarrierText(text: String): Boolean {
+        val normalized = normalizeCarrierText(text)
+        if (normalized.isBlank()) return false
+
+        val resourceLabels = synchronized(unavailableCarrierTexts) {
+            unavailableCarrierTexts.toSet()
+        }
+        val unavailableLabels = resourceLabels.ifEmpty { unavailableCarrierTextFallbacks }
+
+        return unavailableLabels.any { label ->
+            label.isNotBlank() && (normalized == label || normalized.contains(label))
+        }
+    }
+
+    private fun normalizeCarrierText(text: String): String =
+        text
+            .replace(Regex("[\\u200e\\u200f\\u202a-\\u202e\\u2066-\\u2069]"), "")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+            .lowercase(Locale.ROOT)
+
+    private fun buildCarrierText(
+        originalCarriers: List<CharSequence?>,
+        sanitizedCarriers: List<CharSequence?>
+    ): String {
+        val visibleCarriers = sanitizedCarriers
+            .mapNotNull { it?.toString()?.takeIf(String::isNotBlank) }
+        if (visibleCarriers.isEmpty()) return ""
+        if (visibleCarriers.size == 1) return visibleCarriers.first()
+
+        val originalText = originalCarriers
+            .mapNotNull { it?.toString()?.takeIf(String::isNotBlank) }
+            .joinToString()
+        val separator = detectCarrierSeparator(originalText, originalCarriers)
+        return visibleCarriers.joinToString(separator)
+    }
+
+    private fun detectCarrierSeparator(
+        carrierText: String,
+        carriers: List<CharSequence?>
+    ): String {
+        val carrierNames = carriers.mapNotNull { it?.toString()?.takeIf(String::isNotBlank) }
+        if (carrierNames.size < 2) return ", "
+
+        val first = carrierNames[0]
+        val second = carrierNames[1]
+        val firstIndex = carrierText.indexOf(first)
+        if (firstIndex < 0) return ", "
+
+        val separatorStart = firstIndex + first.length
+        val secondIndex = carrierText.indexOf(second, separatorStart)
+        if (secondIndex <= separatorStart) return ", "
+
+        return carrierText.substring(separatorStart, secondIndex)
+    }
+
+    private data class CarrierListField(
+        val field: Field,
+        val holder: Any,
+        val owner: Any,
+        val values: List<CharSequence?>
+    )
+
+    private fun readCarrierListField(info: Any): CarrierListField? {
+        val field = findField(
+            info,
+            listOf("listOfCarriers", "carrierTextList", "carrierTexts", "networkNames")
+        ) ?: return null
+        val value = runCatching { field.get(info) }.getOrNull() ?: return null
+        val values = when (value) {
+            is Array<*> -> value.map { it as? CharSequence }
+            is List<*> -> value.map { it as? CharSequence }
+            else -> return null
+        }
+        return CarrierListField(field, info, value, values)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun writeCarrierListField(
+        carrierList: CarrierListField,
+        values: List<CharSequence?>
+    ) {
+        runCatching {
+            when (val owner = carrierList.owner) {
+                is Array<*> -> values.forEachIndexed { index, value ->
+                    java.lang.reflect.Array.set(owner, index, value)
+                }
+
+                is MutableList<*> -> (owner as MutableList<CharSequence?>).also { list ->
+                    values.forEachIndexed { index, value -> list[index] = value }
+                }
+            }
+        }.onFailure {
+            runCatching { carrierList.field.set(carrierList.holder, values) }
+        }
+    }
+
+    private fun readIntArrayField(info: Any, names: List<String>): IntArray? {
+        val value = readFieldValue(info, names) ?: return null
+        return when (value) {
+            is IntArray -> value
+            is Array<*> -> value.mapNotNull { it as? Int }.toIntArray()
+            else -> null
+        }
+    }
+
+    private fun readFieldValue(instance: Any, names: List<String>): Any? =
+        findField(instance, names)?.let { field -> runCatching { field.get(instance) }.getOrNull() }
+
+    private fun setFieldValue(instance: Any, name: String, value: Any?) {
+        findField(instance, listOf(name))?.let { field ->
+            runCatching { field.set(instance, value) }
+        }
+    }
+
+    private fun findField(instance: Any, names: List<String>): Field? {
+        var clazz: Class<*>? = instance.javaClass
+        while (clazz != null) {
+            names.forEach { name ->
+                runCatching {
+                    val field = clazz.getDeclaredField(name)
+                    field.isAccessible = true
+                    return field
+                }
+            }
+            clazz = clazz.superclass
+        }
+        return null
     }
 
     fun setStatusBarMaxNotificationIcons(loadPackageParam: LoadPackageParam, max: Int) {

--- a/app/src/main/java/io/github/soclear/oneuix/hook/SystemUI.kt
+++ b/app/src/main/java/io/github/soclear/oneuix/hook/SystemUI.kt
@@ -32,6 +32,7 @@ import de.robv.android.xposed.XposedHelpers.callMethod
 import de.robv.android.xposed.XposedHelpers.findAndHookConstructor
 import de.robv.android.xposed.XposedHelpers.findAndHookMethod
 import de.robv.android.xposed.XposedHelpers.findClass
+import de.robv.android.xposed.XposedHelpers.findFieldIfExists
 import de.robv.android.xposed.XposedHelpers.getIntField
 import de.robv.android.xposed.XposedHelpers.getObjectField
 import de.robv.android.xposed.XposedHelpers.setIntField
@@ -58,8 +59,6 @@ object SystemUI {
         Collections.synchronizedSet(Collections.newSetFromMap(WeakHashMap()))
     private val unavailableCarrierSlots = mutableSetOf<Int>()
     private val telephonyManagersBySubId = mutableMapOf<Int, TelephonyManager>()
-    private val fieldCache: MutableMap<FieldCacheKey, Field?> =
-        Collections.synchronizedMap(mutableMapOf())
     private val unavailableCarrierTexts: MutableSet<String> =
         Collections.synchronizedSet(mutableSetOf())
     private var physicalEsimAdapterContext: Context? = null
@@ -1101,11 +1100,6 @@ object SystemUI {
         val values: List<CharSequence?>
     )
 
-    private data class FieldCacheKey(
-        val clazz: Class<*>,
-        val name: String
-    )
-
     private fun readCarrierListField(info: Any): CarrierListField? {
         val field = findField(
             info,
@@ -1159,29 +1153,10 @@ object SystemUI {
     }
 
     private fun findField(instance: Any, names: List<String>): Field? {
-        var clazz: Class<*>? = instance.javaClass
-        while (clazz != null) {
-            names.forEach { name ->
-                findDeclaredField(clazz, name)?.let { return it }
-            }
-            clazz = clazz.superclass
+        names.forEach { name ->
+            findFieldIfExists(instance.javaClass, name)?.let { return it }
         }
         return null
-    }
-
-    private fun findDeclaredField(clazz: Class<*>, name: String): Field? {
-        val cacheKey = FieldCacheKey(clazz, name)
-        synchronized(fieldCache) {
-            if (fieldCache.containsKey(cacheKey)) return fieldCache[cacheKey]
-        }
-
-        val field = runCatching {
-            clazz.getDeclaredField(name).apply { isAccessible = true }
-        }.getOrNull()
-        synchronized(fieldCache) {
-            fieldCache[cacheKey] = field
-        }
-        return field
     }
 
     fun setStatusBarMaxNotificationIcons(loadPackageParam: LoadPackageParam, max: Int) {

--- a/app/src/main/java/io/github/soclear/oneuix/ui/category/DetailPaneSystemUI.kt
+++ b/app/src/main/java/io/github/soclear/oneuix/ui/category/DetailPaneSystemUI.kt
@@ -37,10 +37,13 @@ import androidx.compose.ui.unit.dp
 import io.github.soclear.oneuix.R
 import io.github.soclear.oneuix.data.Preference
 import io.github.soclear.oneuix.ui.SettingViewModel
+import io.github.soclear.oneuix.ui.component.SelectItem
 import io.github.soclear.oneuix.ui.component.SwitchItem
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import kotlin.math.roundToInt
+
+private const val ESIM_ADAPTER_SIM_BOTH = 2
 
 @Composable
 fun DetailPaneSystemUI(
@@ -321,6 +324,33 @@ fun DetailPaneSystemUI(
                 onEvent(SystemUIEvent.StatusBar.HideSecureFolderStatusBarIcon(it))
             }
         )
+        SwitchItem(
+            icon = ImageVector.vectorResource(id = R.drawable.sim_card),
+            title = stringResource(id = R.string.physicalEsimAdapterWorkaround_title),
+            summary = stringResource(id = R.string.physicalEsimAdapterWorkaround_summary),
+            checked = uiState.statusBar.physicalEsimAdapterWorkaround,
+            onCheckedChange = {
+                onEvent(SystemUIEvent.StatusBar.PhysicalEsimAdapterWorkaround(it))
+            }
+        )
+        AnimatedVisibility(uiState.statusBar.physicalEsimAdapterWorkaround) {
+            SelectItem(
+                icon = ImageVector.vectorResource(id = R.drawable.sim_card),
+                title = stringResource(id = R.string.physicalEsimAdapterSimSlot_title),
+                entries = listOf(
+                    stringResource(id = R.string.sim_slot_1),
+                    stringResource(id = R.string.sim_slot_2),
+                    stringResource(id = R.string.sim_slot_both)
+                ),
+                selectedIndex = uiState.statusBar.physicalEsimAdapterSimSlot.coerceIn(
+                    0,
+                    ESIM_ADAPTER_SIM_BOTH
+                ),
+                onSelectedIndexChange = {
+                    onEvent(SystemUIEvent.StatusBar.PhysicalEsimAdapterSimSlot(it))
+                }
+            )
+        }
         SwitchItem(
             icon = ImageVector.vectorResource(id = R.drawable.mobile_screensaver),
             title = stringResource(id = R.string.doubleTapStatusBarToSleep_title),
@@ -671,6 +701,12 @@ sealed interface SystemUIEvent {
         value class HideSecureFolderStatusBarIcon(val value: Boolean) : StatusBar
 
         @JvmInline
+        value class PhysicalEsimAdapterWorkaround(val value: Boolean) : StatusBar
+
+        @JvmInline
+        value class PhysicalEsimAdapterSimSlot(val value: Int) : StatusBar
+
+        @JvmInline
         value class DoubleTapStatusBarToSleep(val value: Boolean) : StatusBar
 
         @JvmInline
@@ -918,6 +954,29 @@ private fun SettingViewModel.onStatusBarEvent(event: SystemUIEvent.StatusBar) {
                     systemUI = preference.systemUI.copy(
                         statusBar = preference.systemUI.statusBar.copy(
                             hideSecureFolderStatusBarIcon = event.value
+                        )
+                    )
+                )
+            }
+
+            is SystemUIEvent.StatusBar.PhysicalEsimAdapterWorkaround -> {
+                preference.copy(
+                    systemUI = preference.systemUI.copy(
+                        statusBar = preference.systemUI.statusBar.copy(
+                            physicalEsimAdapterWorkaround = event.value
+                        )
+                    )
+                )
+            }
+
+            is SystemUIEvent.StatusBar.PhysicalEsimAdapterSimSlot -> {
+                preference.copy(
+                    systemUI = preference.systemUI.copy(
+                        statusBar = preference.systemUI.statusBar.copy(
+                            physicalEsimAdapterSimSlot = event.value.coerceIn(
+                                0,
+                                ESIM_ADAPTER_SIM_BOTH
+                            )
                         )
                     )
                 )

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -25,6 +25,12 @@
     <string name="updateStatusBarClockEverySecond_title">Mettre à jour l\'heure de la barre d\'état chaque seconde</string>
     <string name="updateStatusBarClockEverySecond_summary">Définit également les chiffres avec une police à espacement fixe (monospace)</string>
     <string name="hideSecureFolderStatusBarIcon_title">Masquer l\'icône du dossier sécurisé dans la barre d\'état</string>
+    <string name="physicalEsimAdapterWorkaround_title">Contournement pour adaptateur eSIM physique</string>
+    <string name="physicalEsimAdapterWorkaround_summary">Masque l\'icône de la carte SIM sélectionnée en l\'absence de service ou lorsque seuls les appels d\'urgence sont disponibles</string>
+    <string name="physicalEsimAdapterSimSlot_title">Carte SIM</string>
+    <string name="sim_slot_1">SIM 1</string>
+    <string name="sim_slot_2">SIM 2</string>
+    <string name="sim_slot_both">SIM 1 et SIM 2</string>
     <string name="hideQsBarNearbyDevicesAndDeviceControl_title">Masquer la barre Appareils à proximité et Contrôle des appareils</string>
     <string name="hideQsBarMediaPlayer_title">Masquer la barre du lecteur multimédia dans les paramètres rapides</string>
     <string name="hideQsBarSecurityFooter_title">Masquer la barre d\'avertissement de sécurité dans les paramètres rapides</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -25,6 +25,12 @@
     <string name="updateStatusBarClockEverySecond_title">Обновлять часы в строке состояния каждую секунду</string>
     <string name="updateStatusBarClockEverySecond_summary">Также включает моноширинный шрифт для цифр</string>
     <string name="hideSecureFolderStatusBarIcon_title">Скрыть иконку защищенной папки в строке состояния</string>
+    <string name="physicalEsimAdapterWorkaround_title">Обходной путь для физического eSIM-адаптера</string>
+    <string name="physicalEsimAdapterWorkaround_summary">Скрывает иконку выбранной SIM-карты, если нет обслуживания сети или доступны только экстренные вызовы</string>
+    <string name="physicalEsimAdapterSimSlot_title">SIM-карта</string>
+    <string name="sim_slot_1">SIM 1</string>
+    <string name="sim_slot_2">SIM 2</string>
+    <string name="sim_slot_both">SIM 1 и SIM 2</string>
     <string name="hideQsBarNearbyDevicesAndDeviceControl_title">Скрыть кнопки «Устройства поблизости» и «Упр. устройством»</string>
     <string name="hideQsBarMediaPlayer_title">Скрыть медиаплеер в панели быстрых настроек</string>
     <string name="hideQsBarSecurityFooter_title">Скрыть панель безопасности в быстрых настройках</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -25,6 +25,12 @@
     <string name="updateStatusBarClockEverySecond_title">状态栏时间每秒更新</string>
     <string name="updateStatusBarClockEverySecond_summary">同时设置数字为等宽字体</string>
     <string name="hideSecureFolderStatusBarIcon_title">隐藏安全文件夹状态栏图标</string>
+    <string name="physicalEsimAdapterWorkaround_title">实体 eSIM 适配器兼容处理</string>
+    <string name="physicalEsimAdapterWorkaround_summary">当所选 SIM 卡无服务或仅可拨打紧急电话时隐藏其图标</string>
+    <string name="physicalEsimAdapterSimSlot_title">SIM 卡</string>
+    <string name="sim_slot_1">SIM 1</string>
+    <string name="sim_slot_2">SIM 2</string>
+    <string name="sim_slot_both">SIM 1 和 SIM 2</string>
     <string name="hideQsBarNearbyDevicesAndDeviceControl_title">隐藏快捷设置面板的附近设备和设备控制 Bar</string>
     <string name="hideQsBarMediaPlayer_title">隐藏快捷设置面板的媒体播放器 Bar</string>
     <string name="hideQsBarSecurityFooter_title">隐藏快捷设置面板的安全底部提示 Bar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,12 @@
     <string name="updateStatusBarClockEverySecond_title">Update status bar clock every second</string>
     <string name="updateStatusBarClockEverySecond_summary">Also sets numbers to monospaced font</string>
     <string name="hideSecureFolderStatusBarIcon_title">Hide Secure Folder status bar icon</string>
+    <string name="physicalEsimAdapterWorkaround_title">Workaround for physical eSIM adapter</string>
+    <string name="physicalEsimAdapterWorkaround_summary">Hides the icon for the selected SIM card if there is no service or only emergency calls are available</string>
+    <string name="physicalEsimAdapterSimSlot_title">SIM card</string>
+    <string name="sim_slot_1">SIM 1</string>
+    <string name="sim_slot_2">SIM 2</string>
+    <string name="sim_slot_both">SIM 1 and SIM 2</string>
     <string name="hideQsBarNearbyDevicesAndDeviceControl_title">Hide Nearby Devices and Device Control bar in QS panel</string>
     <string name="hideQsBarMediaPlayer_title">Hide Media Player bar in QS panel</string>
     <string name="hideQsBarSecurityFooter_title">Hide Security footer bar in QS panel</string>


### PR DESCRIPTION
This PR adds a workaround for physical eSIM adapters such as eSIM.me, 9eSIM, and similar SIM-card-shaped eSIM chips.

These adapters normally shouldn't be disabled like a regular SIM through Android's SIM settings since disabling the SIM slot cuts power to the adapter chip itself, which also makes its profile management unavailable until the next device reboot. At the same time, disabling the active eSIM profile through its manager leaves SystemUI with a fake mobile entry that looks like a regular SIM with "no service" or "emergency calls only" state. 

The workaround hides that visual clutter of inactive adapter entry from status bar, QS header and lockscreen while keeping the real SIM slot with manageable chip powered. I think there might be other uses for this feature, but this is how I see it in the first place.

| Enabled  | Disabled |
| ------------- | ------------- |
| <img width="400" height="204" alt="with_module" src="https://github.com/user-attachments/assets/4369a276-7f7d-4fe5-a001-1707eacce0cf" /> | <img width="400" height="204" alt="no_module" src="https://github.com/user-attachments/assets/24512688-aacc-4788-8ca0-8410587ba800" /> |
| <img width="400" height="204" alt="with_module" src="https://github.com/user-attachments/assets/a6bef2e8-d3b3-4edf-8ca3-20a97e3f98ed" /> | <img width="400" height="204" alt="no_module" src="https://github.com/user-attachments/assets/616c7fc0-e24b-4da2-ae44-9a989adfe75e" /> |