### PR TITLE
feat: force allow `display_outdoor_mode`

### DIFF
--- a/app/src/main/java/io/github/soclear/oneuix/data/Preference.kt
+++ b/app/src/main/java/io/github/soclear/oneuix/data/Preference.kt
@@ -87,6 +87,7 @@ data class Preference(
     @Serializable
     data class Settings(
         val showForcePeakRefreshRatePreference: Boolean = true,
+        val supportOutdoorMode: Boolean = false,
         val showMoreBatteryInfo: Boolean = true,
         val showPackageInfo: Boolean = true,
         val showWiFiLinkSpeed: Boolean = false,

--- a/app/src/main/java/io/github/soclear/oneuix/hook/Main.kt
+++ b/app/src/main/java/io/github/soclear/oneuix/hook/Main.kt
@@ -155,6 +155,10 @@ class Main : IXposedHookLoadPackage, IXposedHookInitPackageResources {
                     Settings.showForcePeakRefreshRatePreference(lpparam)
                 }
 
+                if (preference.settings.supportOutdoorMode) {
+                    Settings.supportOutdoorMode(lpparam)
+                }
+
                 if (preference.settings.showMoreBatteryInfo) {
                     Settings.showMoreBatteryInfo(lpparam)
                 }
@@ -253,6 +257,10 @@ class Main : IXposedHookLoadPackage, IXposedHookInitPackageResources {
 
                 if (preference.systemUI.statusBar.hideLockscreenStatusBar) {
                     SystemUI.hideLockscreenStatusBar(lpparam)
+                }
+
+                if (preference.settings.supportOutdoorMode) {
+                    SystemUI.supportOutdoorMode(lpparam)
                 }
 
                 run {

--- a/app/src/main/java/io/github/soclear/oneuix/hook/Settings.kt
+++ b/app/src/main/java/io/github/soclear/oneuix/hook/Settings.kt
@@ -101,6 +101,32 @@ object Settings {
         }
     }
 
+    fun supportOutdoorMode(loadPackageParam: LoadPackageParam) {
+        if (loadPackageParam.packageName != Package.SETTINGS) return
+        try {
+            findAndHookMethod(
+                "com.samsung.android.settings.display.controller.SecOutDoorModePreferenceController",
+                loadPackageParam.classLoader,
+                "isAvailable",
+                returnConstant(true)
+            )
+        } catch (t: Throwable) {
+            XposedBridge.log(t)
+        }
+
+        try {
+            findAndHookMethod(
+                "com.samsung.android.settings.Rune",
+                loadPackageParam.classLoader,
+                "supportOutdoorMode",
+                Context::class.java,
+                returnConstant(true)
+            )
+        } catch (t: Throwable) {
+            XposedBridge.log(t)
+        }
+    }
+
     fun supportAutoPowerOnOff(loadPackageParam: LoadPackageParam) {
         if (loadPackageParam.packageName != Package.SETTINGS) return
 

--- a/app/src/main/java/io/github/soclear/oneuix/hook/SystemUI.kt
+++ b/app/src/main/java/io/github/soclear/oneuix/hook/SystemUI.kt
@@ -164,6 +164,7 @@ object SystemUI {
                 object : XC_MethodHook() {
                     override fun afterHookedMethod(param: MethodHookParam) {
                         val detailView = param.result as? ViewGroup ?: return
+                        if (detailView.findViewWithTag<View>(outdoorModeRowTag()) != null) return
                         val context = param.args[0] as Context
                         addOutdoorModeRow(context, detailView, switchPreferenceClass)
                     }
@@ -185,7 +186,8 @@ object SystemUI {
                 "inflateSwitch",
                 context,
                 detailView
-            ) as LinearLayout
+            ) as View
+            outdoorContainer.tag = outdoorModeRowTag()
 
             val res = context.resources
             val titleId = res.getIdentifier("sec_brightness_outdoor_mode_title", "string", Package.SYSTEMUI)
@@ -193,9 +195,10 @@ object SystemUI {
             val titleViewId = res.getIdentifier("title", "id", Package.SYSTEMUI)
             val summaryViewId = res.getIdentifier("title_summary", "id", Package.SYSTEMUI)
             val switchViewId = res.getIdentifier("title_switch", "id", Package.SYSTEMUI)
+            if (titleId == 0 || titleViewId == 0 || switchViewId == 0) return
 
             outdoorContainer.findViewById<TextView>(titleViewId)?.text =
-                if (titleId != 0) res.getString(titleId) else "Outdoor mode"
+                res.getString(titleId)
 
             outdoorContainer.findViewById<TextView>(summaryViewId)?.apply {
                 text = if (summaryId != 0) res.getString(summaryId) else ""
@@ -212,12 +215,15 @@ object SystemUI {
                 switch.isChecked = !switch.isChecked
             }
 
-            val index = if (detailView.childCount > 1) 2 else detailView.childCount
+            // Keep the row directly below Samsung's Adaptive brightness row.
+            val index = minOf(2, detailView.childCount)
             detailView.addView(outdoorContainer, index)
         } catch (t: Throwable) {
             XposedBridge.log(t)
         }
     }
+
+    private fun outdoorModeRowTag() = "io.github.soclear.oneuix.outdoor_mode_row"
 
     private fun isOutdoorModeEnabled(context: Context): Boolean {
         return (callStaticMethod(

--- a/app/src/main/java/io/github/soclear/oneuix/hook/SystemUI.kt
+++ b/app/src/main/java/io/github/soclear/oneuix/hook/SystemUI.kt
@@ -14,6 +14,7 @@ import android.view.Gravity
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.widget.CompoundButton
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -25,6 +26,7 @@ import de.robv.android.xposed.XC_MethodReplacement.returnConstant
 import de.robv.android.xposed.XposedBridge
 import de.robv.android.xposed.XposedBridge.hookAllMethods
 import de.robv.android.xposed.XposedHelpers.callMethod
+import de.robv.android.xposed.XposedHelpers.callStaticMethod
 import de.robv.android.xposed.XposedHelpers.findAndHookConstructor
 import de.robv.android.xposed.XposedHelpers.findAndHookMethod
 import de.robv.android.xposed.XposedHelpers.findClass
@@ -143,6 +145,100 @@ object SystemUI {
         } catch (t: Throwable) {
             XposedBridge.log(t)
         }
+    }
+
+    fun supportOutdoorMode(loadPackageParam: LoadPackageParam) {
+        if (loadPackageParam.packageName != Package.SYSTEMUI) return
+        try {
+            val switchPreferenceClass = findClass(
+                "com.android.systemui.qs.SecQSSwitchPreference",
+                loadPackageParam.classLoader
+            )
+            findAndHookMethod(
+                "com.android.systemui.settings.brightness.BrightnessDetail\$1",
+                loadPackageParam.classLoader,
+                "createDetailView",
+                Context::class.java,
+                View::class.java,
+                ViewGroup::class.java,
+                object : XC_MethodHook() {
+                    override fun afterHookedMethod(param: MethodHookParam) {
+                        val detailView = param.result as? ViewGroup ?: return
+                        val context = param.args[0] as Context
+                        addOutdoorModeRow(context, detailView, switchPreferenceClass)
+                    }
+                }
+            )
+        } catch (t: Throwable) {
+            XposedBridge.log(t)
+        }
+    }
+
+    private fun addOutdoorModeRow(
+        context: Context,
+        detailView: ViewGroup,
+        switchPreferenceClass: Class<*>
+    ) {
+        try {
+            val outdoorContainer = callStaticMethod(
+                switchPreferenceClass,
+                "inflateSwitch",
+                context,
+                detailView
+            ) as LinearLayout
+
+            val res = context.resources
+            val titleId = res.getIdentifier("sec_brightness_outdoor_mode_title", "string", Package.SYSTEMUI)
+            val summaryId = res.getIdentifier("sec_brightness_outdoor_mode_summary", "string", Package.SYSTEMUI)
+            val titleViewId = res.getIdentifier("title", "id", Package.SYSTEMUI)
+            val summaryViewId = res.getIdentifier("title_summary", "id", Package.SYSTEMUI)
+            val switchViewId = res.getIdentifier("title_switch", "id", Package.SYSTEMUI)
+
+            outdoorContainer.findViewById<TextView>(titleViewId)?.text =
+                if (titleId != 0) res.getString(titleId) else "Outdoor mode"
+
+            outdoorContainer.findViewById<TextView>(summaryViewId)?.apply {
+                text = if (summaryId != 0) res.getString(summaryId) else ""
+                visibility = if (summaryId != 0) View.VISIBLE else View.GONE
+            }
+
+            val outdoorSwitch: CompoundButton? = outdoorContainer.findViewById(switchViewId)
+            outdoorSwitch?.isChecked = isOutdoorModeEnabled(context)
+            outdoorSwitch?.setOnCheckedChangeListener { _, isChecked ->
+                setOutdoorModeEnabled(context, isChecked)
+            }
+            outdoorContainer.setOnClickListener {
+                val switch = outdoorSwitch ?: return@setOnClickListener
+                switch.isChecked = !switch.isChecked
+            }
+
+            val index = if (detailView.childCount > 1) 2 else detailView.childCount
+            detailView.addView(outdoorContainer, index)
+        } catch (t: Throwable) {
+            XposedBridge.log(t)
+        }
+    }
+
+    private fun isOutdoorModeEnabled(context: Context): Boolean {
+        return (callStaticMethod(
+            android.provider.Settings.System::class.java,
+            "getIntForUser",
+            context.contentResolver,
+            "display_outdoor_mode",
+            0,
+            -2
+        ) as Int) != 0
+    }
+
+    private fun setOutdoorModeEnabled(context: Context, enabled: Boolean) {
+        callStaticMethod(
+            android.provider.Settings.System::class.java,
+            "putIntForUser",
+            context.contentResolver,
+            "display_outdoor_mode",
+            if (enabled) 1 else 0,
+            -2
+        )
     }
 
 

--- a/app/src/main/java/io/github/soclear/oneuix/ui/category/DetailPaneSettings.kt
+++ b/app/src/main/java/io/github/soclear/oneuix/ui/category/DetailPaneSettings.kt
@@ -33,6 +33,12 @@ fun DetailPaneSettings(
             onCheckedChange = { onEvent(SettingsEvent.ShowForcePeakRefreshRatePreference(it)) },
         )
         SwitchItem(
+            icon = ImageVector.vectorResource(id = R.drawable.light_mode),
+            title = stringResource(id = R.string.supportOutdoorMode_title),
+            checked = uiState.supportOutdoorMode,
+            onCheckedChange = { onEvent(SettingsEvent.SupportOutdoorMode(it)) }
+        )
+        SwitchItem(
             icon = ImageVector.vectorResource(id = R.drawable.battery),
             title = stringResource(id = R.string.showMoreBatteryInfo_title),
             summary = stringResource(id = R.string.showMoreBatteryInfo_summary),
@@ -74,6 +80,9 @@ sealed interface SettingsEvent {
     value class ShowForcePeakRefreshRatePreference(val value: Boolean) : SettingsEvent
 
     @JvmInline
+    value class SupportOutdoorMode(val value: Boolean) : SettingsEvent
+
+    @JvmInline
     value class ShowMoreBatteryInfo(val value: Boolean) : SettingsEvent
 
     @JvmInline
@@ -95,6 +104,12 @@ fun SettingViewModel.onSettingsEvent(event: SettingsEvent) {
             is SettingsEvent.ShowForcePeakRefreshRatePreference -> preference.copy(
                 settings = preference.settings.copy(
                     showForcePeakRefreshRatePreference = event.value
+                )
+            )
+
+            is SettingsEvent.SupportOutdoorMode -> preference.copy(
+                settings = preference.settings.copy(
+                    supportOutdoorMode = event.value
                 )
             )
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -72,6 +72,7 @@
     <string name="showMemoryUsageInRecents_title">Afficher l\'utilisation de la RAM dans les applications récentes</string>
     <string name="showForcePeakRefreshRatePreference_title">Afficher l\'option Forcer le taux de rafraîchissement maximal</string>
     <string name="showForcePeakRefreshRatePreference_summary">Rechercher \"Force peak refresh rate\" dans les paramètres</string>
+    <string name="supportOutdoorMode_title">Déverrouiller le mode Extérieur</string>
     <string name="disablePinVerifyPer72h_title">Désactiver la vérification du code PIN toutes les 72 heures</string>
     <string name="hideAODStatusBar_title">Masquer la barre d\'état sur l\'AOD</string>
     <string name="aodLockSupportLunar_title">Afficher le calendrier lunaire chinois sur l\'AOD</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -72,6 +72,7 @@
     <string name="showMemoryUsageInRecents_title">Использование памяти в меню запущенных приложений</string>
     <string name="showForcePeakRefreshRatePreference_title">Пункт «Частота обновления экрана» в параметрах разработчика</string>
     <string name="showForcePeakRefreshRatePreference_summary">Появится в поиске настроек как «Частота обновления экрана»</string>
+    <string name="supportOutdoorMode_title">Разблокировать режим “На улице”</string>
     <string name="disablePinVerifyPer72h_title">Отключить подтверждение ПИН-кода каждые 72 часа</string>
     <string name="hideAODStatusBar_title">Скрыть строку состояния на AOD</string>
     <string name="aodLockSupportLunar_title">Лунный календарь на AOD и экране блокировки</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -72,6 +72,7 @@
     <string name="showMemoryUsageInRecents_title">最近任务页面显示内存信息</string>
     <string name="showForcePeakRefreshRatePreference_title">开发者选项显示强制最大刷新率选项</string>
     <string name="showForcePeakRefreshRatePreference_summary">设置中搜索 Force peak refresh rate</string>
+    <string name="supportOutdoorMode_title">解锁户外模式</string>
     <string name="disablePinVerifyPer72h_title">禁用每 72 小时验证锁屏密码</string>
     <string name="hideAODStatusBar_title">隐藏息屏提醒的状态栏</string>
     <string name="aodLockSupportLunar_title">息屏提醒显示中国农历</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@
     <string name="showMemoryUsageInRecents_title">Show memory usage in Recents page</string>
     <string name="showForcePeakRefreshRatePreference_title">Show \'Force peak refresh rate\' in Developer options</string>
     <string name="showForcePeakRefreshRatePreference_summary">Search for \'Force peak refresh rate\' in Settings</string>
+    <string name="supportOutdoorMode_title">Unlock Outdoor mode</string>
     <string name="disablePinVerifyPer72h_title">Disable PIN verification every 72 hours</string>
     <string name="hideAODStatusBar_title">Hide AOD status bar</string>
     <string name="aodLockSupportLunar_title">Show Chinese Lunar calendar on AOD/Lock screen</string>


### PR DESCRIPTION
This PR unlocks the "Outdoor mode" toggle in Settings -> Display and forces the "Outdoor mode" switch to be always shown in the QS brightness details. Tested on Galaxy S23 with One UI 6.1.

<img width="180" height="390" alt="Screenshot_20260521_171309_Settings" src="https://github.com/user-attachments/assets/49a6774e-2a6c-4236-b926-d605b09e7aa0" />
<img width="180" height="390" alt="Screenshot_20260521_171315_Settings" src="https://github.com/user-attachments/assets/add88bbc-098b-4d1d-aa54-0c3fe81cf0f9" />
